### PR TITLE
resume html overflow to 'visible' instead of 'auto' when closing

### DIFF
--- a/jquery.bpopup.js
+++ b/jquery.bpopup.js
@@ -208,7 +208,7 @@
         }
         function unbindEvents() {
             if (!o.scrollBar) {
-                $('html').css('overflow', 'auto');
+                $('html').css('overflow', 'visible');
             }
             $('.b-modal.'+id).unbind('click');
             d.unbind('keydown.'+id);


### PR DESCRIPTION
when a popup with option 'scrollBar' set to false being closed,
resume html overflow to 'visible' instead of 'auto'.
