### PR TITLE
Calling bPopup().close() doesn't fire onClose callback

### DIFF
--- a/jquery.bpopup.js
+++ b/jquery.bpopup.js
@@ -17,7 +17,7 @@
         }
 
 		// OPTIONS
-        var o 				= $.extend({}, $.fn.bPopup.defaults, options);
+        var o 				= $.extend({}, $.fn.bPopup.defaults, this.data('bPopup'), options);
 		
 		// HIDE SCROLLBAR?  
         if (!o.scrollBar)
@@ -67,6 +67,7 @@
         // HELPER FUNCTIONS - PRIVATE
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////
         function init() {
+          $popup.data('bPopup', o);
             triggerCall(o.onOpen);
 			popups = ($w.data('bPopup') || 0) + 1, id = prefix + popups + '__',fixedVPos = o.position[1] !== 'auto', fixedHPos = o.position[0] !== 'auto', fixedPosStyle = o.positionStyle === 'fixed', height = $popup.outerHeight(true), width = $popup.outerWidth(true);
             o.loadUrl ? createContent() : open();


### PR DESCRIPTION
If we open a new modal with a `onClose` callback, say as in:

```
        $("#modal").bPopup({
          onClose: function() {
            console.log('Closed');
          }
        });
```

When we try to close it using `$('#modal').bPopup().close()` the `onClose` callback is not fired. This happens because when `$('#modal').bPopup()` is called, it overrides the variable that holds the options with those of the default values of `$.fn.bPopup.defaults`. This means that what we had set before as `onClose`  always gets set back to `false`.

This PR changes it so that we also check `this.data('bPopup')` for previous set options for the modal. If we redefine them in another call, say:

```
        $("#modal").bPopup({
          onClose: function() {
            console.log('Closed again');
          }
        });
```

It should still work since we're still extending the var `o` with `options`.
