### PR TITLE
Changes to the close() function to now call the onClose callback

### DIFF
--- a/jquery.bpopup.js
+++ b/jquery.bpopup.js
@@ -51,6 +51,8 @@
         // PUBLIC FUNCTION - call it: $(element).bPopup().close();
 		////////////////////////////////////////////////////////////////////////////////////////////////////////////
         $popup.close = function() {
+            o = this.data('bPopup');
+            id = prefix +$w.data('bPopup') + '__';
             close();
         };
 		


### PR DESCRIPTION
The current version has a bug where calling the public close() function does not call the onClose callback function. Added functionality to the public close() function so that the onClose callback function is called.